### PR TITLE
[MERGE SECOND] Added fix for event stream and jobsets

### DIFF
--- a/armada_jupyter/armada_utils.py
+++ b/armada_jupyter/armada_utils.py
@@ -101,7 +101,10 @@ def check_job_status(client: ArmadaClient, submission: Submission, job_id: str) 
                     # If queued or pending
                     # Note: In theory this could just be pending, but incase that event
                     # is missed, we also check for queued.
-                    if event.type == EventType.queued or event.type == EventType.pending:
+                    if (
+                        event.type == EventType.queued
+                        or event.type == EventType.pending
+                    ):
                         print("Job is Queued")
                         if not submission.wait_for_jobs_running:
                             return True

--- a/armada_jupyter/armada_utils.py
+++ b/armada_jupyter/armada_utils.py
@@ -98,7 +98,10 @@ def check_job_status(client: ArmadaClient, submission: Submission, job_id: str) 
                 # find the job_id that matches the event
                 if event.message.job_id == job_id:
 
-                    if event.type == EventType.queued:
+                    # If queued or pending
+                    # Note: In theory this could just be pending, but incase that event
+                    # is missed, we also check for queued.
+                    if event.type == EventType.queued or event.type == EventType.pending:
                         print("Job is Queued")
                         if not submission.wait_for_jobs_running:
                             return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "armada_jupyter"
 version = "0.1.0"
 description = "Submit JupyterLab Pods to Armada"
 readme = "README.md"
-requires-python = ">=3.7,<3.9"
+requires-python = ">=3.7"
 dependencies = ["armada_client", "typer", "pyyaml", "types-PyYAML"]
 license = { text = "Apache Software License" }
 authors = [{ name = "G-Research Open Source Software", email = "armada@armadaproject.io" }]


### PR DESCRIPTION
Closes #60 

I could run just `next(event_stream)` in the try/except, but that event we are skipping might be the one the user is looking for, so I think I need to have all the code in the loop. If people prefer I can run the event_stream loop code in a seperate function to make it cleaner.